### PR TITLE
Add Support For Laravel 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,36 +2,38 @@ name: Build
 
 on:
   push:
-    paths-ignore: ['*.md']
+    paths-ignore: ["*.md"]
   pull_request:
-    paths-ignore: [ '*.md' ]
-    branches: [ master, main ]
+    paths-ignore: ["*.md"]
+    branches: [main]
 
 jobs:
   analysis:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.2]
+        php: [8.3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: eloquent-repository-analysis
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run static analysis
@@ -42,57 +44,61 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [8.0, 8.1, 8.2]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath,   intl, gd, exif, iconv
           coverage: none
       - name: Remove some dev dependencies
         run: composer remove "ekino/phpstan-banned-code" "nunomaduro/larastan" "phpmd/phpmd" "phpstan/phpstan-deprecation-rules" "sebastian/phpcpd" --dev --no-update
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: eloquent-repository-test
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run the test suite
         run: vendor/bin/phpunit
   test-coverage:
     name: Test (PHP ${{ matrix.php }})
-    needs: [ analysis ]
+    needs: [analysis]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.2 ]
+        php: [8.3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: eloquent-repository-test
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run the Coverage test suite

--- a/composer.json
+++ b/composer.json
@@ -21,22 +21,20 @@
     "source": "https://github.com/richan-fongdasen/eloquent-repository"
   },
   "require": {
-    "php": "^7.4|^8.0",
-    "illuminate/cache": "^8.0|^9.0|^10.0",
-    "illuminate/database": "^8.0|^9.0|^10.0",
-    "illuminate/support": "^8.0|^9.0|^10.0"
+    "php": "^8.0",
+    "illuminate/cache": "^8.0|^9.0|^10.0|^11.0",
+    "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
+    "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
   },
   "require-dev": {
     "ekino/phpstan-banned-code": "^1.0",
     "fakerphp/faker": "^1.14",
+    "larastan/larastan": "^1.0|^2.0",
     "mockery/mockery": "^1.4",
-    "nunomaduro/larastan": "^1.0|^2.0",
-    "orchestra/database": "^6.0|dev-master",
-    "orchestra/testbench": "^6.0|^7.0|^8.0",
+    "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
     "phpmd/phpmd": "^2.11",
     "phpstan/phpstan-deprecation-rules": "^1.0",
-    "phpunit/phpunit": "^9.5",
-    "sebastian/phpcpd": "^6.0"
+    "phpunit/phpunit": "^9.5|^10.0|^11.0"
   },
   "config": {
     "sort-packages": true
@@ -56,8 +54,7 @@
     "analyse": [
       "composer check-syntax",
       "composer phpstan-analysis",
-      "composer phpmd-analysis",
-      "vendor/bin/phpcpd --min-lines=3 --min-tokens=36 src/"
+      "composer phpmd-analysis"
     ],
     "check-syntax": [
       "! find src -type f -name \"*.php\" -exec php -l {} \\; |  grep -v 'No syntax errors'",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - vendor/nunomaduro/larastan/extension.neon
+    - vendor/larastan/larastan/extension.neon
     - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/ekino/phpstan-banned-code/extension.neon
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Eloquent Repository Test Suite">
       <directory suffix="Tests.php">./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,5 @@
-[![Build Status](https://travis-ci.org/richan-fongdasen/eloquent-repository.svg?branch=master)](https://travis-ci.org/richan-fongdasen/eloquent-repository)
+[![Build](https://github.com/richan-fongdasen/eloquent-repository/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/richan-fongdasen/eloquent-repository/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/richan-fongdasen/eloquent-repository/branch/master/graph/badge.svg)](https://codecov.io/gh/richan-fongdasen/eloquent-repository)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/richan-fongdasen/eloquent-repository/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/richan-fongdasen/eloquent-repository/?branch=master)
 [![StyleCI Analysis Status](https://github.styleci.io/repos/135787392/shield?branch=master)](https://github.styleci.io/repos/135787392)
 [![Total Downloads](https://poser.pugx.org/richan-fongdasen/eloquent-repository/d/total.svg)](https://packagist.org/packages/richan-fongdasen/eloquent-repository)
 [![Latest Stable Version](https://poser.pugx.org/richan-fongdasen/eloquent-repository/v/stable.svg)](https://packagist.org/packages/richan-fongdasen/eloquent-repository)

--- a/tests/Concerns/HasCriteriasTests.php
+++ b/tests/Concerns/HasCriteriasTests.php
@@ -4,6 +4,7 @@ namespace RichanFongdasen\Repository\Tests\Concerns;
 
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Repository\Criterias\PaginationCriteria;
 use RichanFongdasen\Repository\Criterias\WithTrashedCriteria;
 use RichanFongdasen\Repository\Tests\Supports\Models\Post;
@@ -25,14 +26,14 @@ class HasCriteriasTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->repository = app(PostRepository::class);
     }
 
-    /** @test */
+    #[Test]
     public function criterias_can_be_flushed_on_demand()
     {
         $this->repository->pushCriteria([WithTrashedCriteria::class]);
@@ -41,7 +42,7 @@ class HasCriteriasTests extends TestCase
         $this->assertNull($this->repository->getCriteria(WithTrashedCriteria::class));
     }
 
-    /** @test */
+    #[Test]
     public function it_will_returns_collection_when_getting_criterias_without_specifying_any_class_name()
     {
         $this->repository->pushCriteria([
@@ -56,7 +57,7 @@ class HasCriteriasTests extends TestCase
         $this->assertInstanceOf(PaginationCriteria::class, $criterias->last());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_create_criteria_with_the_given_class_name()
     {
         $this->repository->pushCriteria([WithTrashedCriteria::class]);
@@ -65,7 +66,7 @@ class HasCriteriasTests extends TestCase
         $this->assertInstanceOf(WithTrashedCriteria::class, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_push_the_given_criteria_into_the_collection()
     {
         $criteria = new WithTrashedCriteria;
@@ -75,14 +76,14 @@ class HasCriteriasTests extends TestCase
         $this->assertInstanceOf(WithTrashedCriteria::class, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_raise_exception_when_pushing_non_criteria_object()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->repository->pushCriteria([$this->repository->newModel()]);
     }
 
-    /** @test */
+    #[Test]
     public function criteria_can_be_removed_on_demand()
     {
         $this->repository->pushCriteria([
@@ -97,7 +98,7 @@ class HasCriteriasTests extends TestCase
         $this->assertInstanceOf(PaginationCriteria::class, $criterias->first());
     }
 
-    /** @test */
+    #[Test]
     public function not_on_demand_criteria_will_be_implemented_immediately()
     {
         $repository = app(PostCategoryRepository::class);
@@ -113,7 +114,7 @@ class HasCriteriasTests extends TestCase
             ->orderBy('created_at', 'desc');
 
         $query = $repository->newQuery();
-        
+
         $this->assertEquals($expected, $query->toSql());
     }
 }

--- a/tests/Concerns/ManipulateDataTests.php
+++ b/tests/Concerns/ManipulateDataTests.php
@@ -2,6 +2,7 @@
 
 namespace RichanFongdasen\Repository\Tests\Concerns;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Repository\Tests\Supports\Models\Post;
 use RichanFongdasen\Repository\Tests\Supports\Models\PostCategory;
 use RichanFongdasen\Repository\Tests\Supports\Repositories\PostCategoryRepository;
@@ -22,7 +23,7 @@ class ManipulateDataTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -43,7 +44,7 @@ class ManipulateDataTests extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_create_new_model_based_on_the_given_attribute()
     {
         $model = $this->createNewPost();
@@ -54,7 +55,7 @@ class ManipulateDataTests extends TestCase
         $this->assertTrue($model->wasRecentlyCreated);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_delete_existing_model_based_on_the_given_primary_key()
     {
         $model = $this->createNewPost();
@@ -63,7 +64,7 @@ class ManipulateDataTests extends TestCase
         $this->assertNull($this->repository->find($model->getKey()));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_perform_first_or_create_operation()
     {
         $this->createNewPost();
@@ -80,7 +81,7 @@ class ManipulateDataTests extends TestCase
         $this->assertTrue($model->wasRecentlyCreated);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_perform_first_or_new_operation()
     {
         $this->createNewPost();
@@ -93,11 +94,11 @@ class ManipulateDataTests extends TestCase
         $this->assertFalse($model->exists);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_restore_deleted_model_based_on_the_given_primary_key()
     {
         $repository = app(PostCategoryRepository::class);
-        $model = $repository->create(['title' => 'test category']);        
+        $model = $repository->create(['title' => 'test category']);
 
         $repository->delete($model->getKey());
         $repository->restore($model->getKey());
@@ -110,7 +111,7 @@ class ManipulateDataTests extends TestCase
         $this->assertFalse($restored->wasRecentlyCreated);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_update_created_model()
     {
         $model = $this->createNewPost();
@@ -126,7 +127,7 @@ class ManipulateDataTests extends TestCase
         $this->assertEquals('updated content', $updated->content);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_perform_update_or_create_operation()
     {
         $this->createNewPost();

--- a/tests/Concerns/RetrieveDataTests.php
+++ b/tests/Concerns/RetrieveDataTests.php
@@ -5,6 +5,7 @@ namespace RichanFongdasen\Repository\Tests\Concerns;
 use ErrorException;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Repository\Criterias\PaginationCriteria;
 use RichanFongdasen\Repository\Criterias\WithTrashedCriteria;
 use RichanFongdasen\Repository\Tests\Supports\Models\Post;
@@ -33,7 +34,7 @@ class RetrieveDataTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -43,7 +44,7 @@ class RetrieveDataTests extends TestCase
         $this->post = app(PostRepository::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_all_of_database_records_available()
     {
         $collection = $this->postCategory->all();
@@ -52,7 +53,7 @@ class RetrieveDataTests extends TestCase
         $this->assertEquals(3, $collection->count());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_find_a_single_model_by_the_given_primary_key()
     {
         $post = $this->post->find(18);
@@ -62,7 +63,7 @@ class RetrieveDataTests extends TestCase
         $this->assertEquals(18, $post->getKey());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_find_multiple_models_by_the_given_primary_keys()
     {
         $keys = [3, 9, 15];
@@ -80,7 +81,7 @@ class RetrieveDataTests extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_can_find_multiple_models_based_on_the_given_column_and_value()
     {
         $collection = $this->post->select()->findAllBy('post_category_id', 2);
@@ -90,7 +91,7 @@ class RetrieveDataTests extends TestCase
         $this->assertEquals($count, $collection->count());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_find_multiple_models_by_the_given_query_scopes()
     {
         $collection = $this->post->limit(-10)
@@ -106,7 +107,7 @@ class RetrieveDataTests extends TestCase
         $this->assertEquals($count, $collection->count());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_find_a_single_model_by_the_given_column_and_value()
     {
         $actual = $this->post->select(['id', 'post_category_id', 'user_id', 'title'])
@@ -129,7 +130,7 @@ class RetrieveDataTests extends TestCase
         $this->assertNull($actual->modified_at);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_find_a_single_model_by_the_given_query_scopes()
     {
         $actual = $this->post->select(['id', 'post_category_id', 'user_id', 'title'])
@@ -157,7 +158,7 @@ class RetrieveDataTests extends TestCase
         $this->assertNull($actual->modified_at);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_normalize_null_sort_direction()
     {
         $expected = \DB::table('posts')->orderBy('post_category_id', 'asc')->toSql();
@@ -167,7 +168,7 @@ class RetrieveDataTests extends TestCase
         $this->assertEquals($expected, $query->toSql());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_an_array_list_as_expected()
     {
         $collection = $this->postCategory->pluck('title', 'id');
@@ -179,14 +180,14 @@ class RetrieveDataTests extends TestCase
         $this->assertEquals(3, $collection->count());
     }
 
-    /** @test */
+    #[Test]
     public function it_raises_exception_when_paginating_query_without_using_pagination_criteria()
     {
         $this->expectException(ErrorException::class);
         $paginator = $this->post->paginate(['published' => true]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_build_paginated_records_based_on_the_given_query_scopes()
     {
         $paginator = $this->post->pushCriteria([PaginationCriteria::class])
@@ -198,7 +199,7 @@ class RetrieveDataTests extends TestCase
         $this->assertEquals(2, $paginator->perPage());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_row_and_some_of_its_relationship_from_database()
     {
         $actual = $this->post->with(['postCategory'])->find(1)->toArray();

--- a/tests/Criterias/PaginationCriteriaTests.php
+++ b/tests/Criterias/PaginationCriteriaTests.php
@@ -4,6 +4,7 @@ namespace RichanFongdasen\Repository\Tests\Criterias;
 
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Repository\Criterias\PaginationCriteria;
 use RichanFongdasen\Repository\Tests\Supports\Models\PostCategory;
 use RichanFongdasen\Repository\Tests\Supports\Repositories\PostRepository;
@@ -37,7 +38,7 @@ class PaginationCriteriaTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -65,7 +66,7 @@ class PaginationCriteriaTests extends TestCase
             ->andReturn($this->page);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_initiated_using_the_given_request_object()
     {
         $this->prepareMockedRequest();
@@ -76,7 +77,7 @@ class PaginationCriteriaTests extends TestCase
         $this->assertEquals($this->page, $this->getPropertyValue($criteria, 'currentPage'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_normalize_invalid_request_page_value()
     {
         $baseUrl = 'http://localhost:8000/news/index';
@@ -96,7 +97,7 @@ class PaginationCriteriaTests extends TestCase
         $this->assertEquals(1, $this->getPropertyValue($criteria, 'currentPage'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_per_page_value()
     {
         $this->prepareMockedRequest();
@@ -107,7 +108,7 @@ class PaginationCriteriaTests extends TestCase
         $this->assertEquals(30, $this->getPropertyValue($criteria, 'perPage'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_normalize_invalid_per_page_value()
     {
         $this->prepareMockedRequest();
@@ -119,7 +120,7 @@ class PaginationCriteriaTests extends TestCase
         $this->assertEquals(15, $this->getPropertyValue($criteria, 'perPage'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_build_paginator_as_expected()
     {
         $this->seeder->seedAll();

--- a/tests/Criterias/WithTrashedCriteriaTests.php
+++ b/tests/Criterias/WithTrashedCriteriaTests.php
@@ -2,6 +2,7 @@
 
 namespace RichanFongdasen\Repository\Tests\Criterias;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Repository\Criterias\WithTrashedCriteria;
 use RichanFongdasen\Repository\Tests\Supports\Models\Post;
 use RichanFongdasen\Repository\Tests\Supports\Repositories\PostCategoryRepository;
@@ -28,7 +29,7 @@ class WithTrashedCriteriaTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -36,7 +37,7 @@ class WithTrashedCriteriaTests extends TestCase
         $this->repository = app(PostCategoryRepository::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_confirm_if_the_current_affected_model_uses_soft_deletes()
     {
         $post = new Post;
@@ -48,7 +49,7 @@ class WithTrashedCriteriaTests extends TestCase
         $this->assertTrue($this->criteria->modelHasSoftDeletes());
     }
 
-    /** @test */
+    #[Test]
     public function it_will_manipulate_query_if_the_model_uses_soft_deletes()
     {
         $expected = \DB::table('post_categories')->select(['*'])->toSql();
@@ -58,7 +59,7 @@ class WithTrashedCriteriaTests extends TestCase
         $this->assertEquals($expected, $query->toSql());
     }
 
-    /** @test */
+    #[Test]
     public function it_wont_manipulate_query_if_the_model_doesnt_use_soft_deletes()
     {
         $post = new Post;

--- a/tests/EloquentRepositoryTests.php
+++ b/tests/EloquentRepositoryTests.php
@@ -2,6 +2,7 @@
 
 namespace RichanFongdasen\Repository\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Repository\Criterias\WithTrashedCriteria;
 use RichanFongdasen\Repository\Tests\Supports\Models\Post;
 use RichanFongdasen\Repository\Tests\Supports\Repositories\PostCategoryRepository;
@@ -21,7 +22,7 @@ class EloquentRepositoryTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -30,7 +31,7 @@ class EloquentRepositoryTests extends TestCase
         $this->repository = app(PostRepository::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_new_model_instance_as_expected()
     {
         $model = $this->repository->newModel();
@@ -40,7 +41,7 @@ class EloquentRepositoryTests extends TestCase
         $this->assertNull($model->getKey());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_new_prepared_eloquent_query_object_as_expected()
     {
         $this->repository->select(['id', 'post_category_id', 'user_id', 'title'])
@@ -48,7 +49,7 @@ class EloquentRepositoryTests extends TestCase
             ->orderBy('created_at', 'desc');
 
         $query = $this->repository->newQuery();
-        
+
         $expected = \DB::table('posts')
             ->select(['id', 'post_category_id', 'user_id', 'title'])
             ->limit(5)
@@ -57,7 +58,7 @@ class EloquentRepositoryTests extends TestCase
         $this->assertEquals($expected, $query->toSql());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_plain_eloquent_query_object_as_expected()
     {
         $repository = app(PostCategoryRepository::class);
@@ -66,7 +67,7 @@ class EloquentRepositoryTests extends TestCase
             ->orderBy('created_at', 'desc');
 
         $query = $repository->plainQuery();
-        
+
         $expected = \DB::table('post_categories')->where('post_categories.deleted_at', null)
             ->toSql();
 

--- a/tests/ScopeBuilderTests.php
+++ b/tests/ScopeBuilderTests.php
@@ -2,6 +2,7 @@
 
 namespace RichanFongdasen\Repository\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Repository\Criterias\WithTrashedCriteria;
 use RichanFongdasen\Repository\ScopeBuilder;
 use RichanFongdasen\Repository\Tests\Supports\Models\Post;
@@ -21,17 +22,17 @@ class ScopeBuilderTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->repository = app(PostRepository::class);
     }
 
-    /** @test */
+    #[Test]
     public function pass_through_the_query_scope_on_numeric_columns()
     {
-        $datetime = date('Y-m-d H:i:s', time()-1209600); // two weeks ago
+        $datetime = date('Y-m-d H:i:s', time() - 1209600); // two weeks ago
         $params = [
             ['post_category_id', 1],
             ['created_at', '>', $datetime]
@@ -46,12 +47,12 @@ class ScopeBuilderTests extends TestCase
             $query = $this->repository->newQuery();
 
             ScopeBuilder::apply($query, $column, $value);
-            
+
             $this->assertEquals($expected[$column], $query->toSql());
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_can_handle_single_scope_application_with_single_value_correctly()
     {
         $expected = \DB::table('posts')->where('published', true)->toSql();
@@ -61,7 +62,7 @@ class ScopeBuilderTests extends TestCase
         $this->assertEquals($expected, $query->toSql());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_handle_single_scope_application_with_multiple_values_correctly()
     {
         $expected = \DB::table('posts')
@@ -72,7 +73,7 @@ class ScopeBuilderTests extends TestCase
         $this->assertEquals($expected, $query->toSql());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_generate_and_apply_multiple_scopes_correctly()
     {
         $expected = \DB::table('posts')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,7 +31,7 @@ abstract class TestCase extends BaseTest
     {
         $this->app = $app;
         $this->seeder = new Seeder;
-        
+
         $app['config']->set('cache.default', 'array');
         $app['config']->set('database.default', 'testbench');
         $app['config']->set('database.connections.testbench', [
@@ -49,8 +49,7 @@ abstract class TestCase extends BaseTest
      */
     protected function getPackageAliases($app)
     {
-        return [
-        ];
+        return [];
     }
 
     /**
@@ -61,9 +60,7 @@ abstract class TestCase extends BaseTest
      */
     protected function getPackageProviders($app)
     {
-        return [
-            \Orchestra\Database\ConsoleServiceProvider::class,
-        ];
+        return [];
     }
 
     /**
@@ -95,7 +92,7 @@ abstract class TestCase extends BaseTest
         $reflection = new \ReflectionClass(get_class($object));
         $property = $reflection->getProperty($propertyName);
         $property->setAccessible(true);
- 
+
         return $property->getValue($object);
     }
 
@@ -106,7 +103,7 @@ abstract class TestCase extends BaseTest
      */
     protected function listenForAnyQueries()
     {
-        \DB::listen(function($query) {
+        \DB::listen(function ($query) {
             echo "\r\n" . $query->sql . "\r\n";
             return true;
         });
@@ -129,7 +126,7 @@ abstract class TestCase extends BaseTest
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
* Add support for Laravel 11
* Add support for PHP 8.3
* Drop support for PHP 7.4
* Update package dependencies
* Update PHP Unit configuration
* Update the test codes from using doc-comment metadata to use PHP 8 attribute
* Update Github actions workflow's configuration
* Update readme